### PR TITLE
Relax MSRV to 1.64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.64.0
+          - rust: 1.65.0
             platform: { os: "ubuntu-latest", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"
           # Test future versions of Rust and Python

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
         ]
         include:
           # Test minimal supported Rust version
-          - rust: 1.79.0
+          - rust: 1.64.0
             platform: { os: "ubuntu-latest", rust-target: "x86_64-unknown-linux-gnu" }
             msrv: "MSRV"
           # Test future versions of Rust and Python

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ndarray-einsum"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.64"
+rust-version = "1.65"
 license = "Apache-2.0"
 authors = ["oracleofnj <jared.samet@aya.yale.edu>", "Matthew Treinish <mtreinish@kortar.org>"]
 repository = "https://github.com/mtreinish/ndarray-einsum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ndarray-einsum"
 version = "0.8.0"
 edition = "2021"
-rust-version = "1.79"
+rust-version = "1.64"
 license = "Apache-2.0"
 authors = ["oracleofnj <jared.samet@aya.yale.edu>", "Matthew Treinish <mtreinish@kortar.org>"]
 repository = "https://github.com/mtreinish/ndarray-einsum"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ ndarray_einsum = "0.9.0"
 
 src/main.rs:
 
-```
+```rust
 use ndarray::prelude::*;
 use ndarray_einsum::*;
 
@@ -36,7 +36,7 @@ fn main() {
 
 General algorithm description in semi-Rust pseudocode
 
-```
+```rust
 FirstStep = Singleton({
   contraction: Contraction,
 }) | Pair({

--- a/src/optimizers.rs
+++ b/src/optimizers.rs
@@ -154,7 +154,7 @@ fn generate_path(sized_contraction: &SizedContraction, tensor_order: &[usize]) -
         1 => {
             // If there's only one input tensor, make a single-step path consisting of a
             // singleton contraction (operand_nums = None).
-            ContractionOrder::Singleton(permuted_contraction.clone())
+            ContractionOrder::Singleton(permuted_contraction)
         }
         2 => {
             // If there's exactly two input tensors, make a single-step path consisting


### PR DESCRIPTION
The MSRV should probably track ndarray's which is currently 1.64. This commit relaxes the msrv to do that.