### PR TITLE
Bump package version for a new release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ndarray-einsum"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "approx",
  "hashbrown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ndarray-einsum"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.65"
 license = "Apache-2.0"


### PR DESCRIPTION
This commit bumps the package version to 0.9.0 to indicate a new release. While this release only bumps depdendencies but since this package is heavily coupled to ndarray and that version is bumped a minor version increment seemed appropriate.